### PR TITLE
Only include .vue files in type def creation

### DIFF
--- a/build/build-type-def.js
+++ b/build/build-type-def.js
@@ -5,6 +5,9 @@ const { resolve, join } = require('path')
 
 const componentsDir = resolve(__dirname, '../src/components')
 const vueFiles = fs.readdirSync(componentsDir).map(fileName => {
+  if (!fileName.match(/\.vue$/)) {
+    return
+  }
   const fullPath = join(componentsDir, fileName)
   const source = fs.readFileSync(fullPath).toString()
   const componentName = fileName.replace(/\.vue$/g, '')
@@ -17,14 +20,14 @@ const vueFiles = fs.readdirSync(componentsDir).map(fileName => {
     outputName,
     source,
   }
-})
+}).filter(Boolean)
 
 const distDir = resolve(__dirname, '../dist')
 
 let typeDef = `import Vue, { VueConstructor } from "vue"\n\n`
 
 vueFiles.forEach(component => {
-  typeDef += `export const ${component.componentName}: VueConstructor<Vue>\n` 
+  typeDef += `export const ${component.componentName}: VueConstructor<Vue>\n`
 })
 
 fs.writeFileSync(join(distDir, 'fishtank-vue.d.ts'), typeDef)


### PR DESCRIPTION
The original logic for this build process walked the `src/components`
directory and created a type export for every file.  This was not taking
into account files that were not `.vue` single file components being put
there, which is now happening with the markdown example files.  This
ignores any files that do not end in `.vue` when generating types.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [ ] Have you added an explanation of what your feature does or changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?