### PR TITLE
feat: added optional required prop for FishTankTextInput

### DIFF
--- a/dev/views/InputText.vue
+++ b/dev/views/InputText.vue
@@ -14,6 +14,12 @@
       type="number"
       error/>
     <InputText
+      label="Input Required Example"
+      type="number"
+      @reset="clearError"
+      required
+      />
+    <InputText
       v-model="val"
       label="Input Number Error Example"
       type="number"

--- a/src/components/FishTankTextInput.vue
+++ b/src/components/FishTankTextInput.vue
@@ -11,6 +11,12 @@
         :class="$style.inputTextLabel"
       >
         {{ label }}
+        <span
+          v-if="required"
+          :class="$style.inputTextLabelRequired"
+        >
+        *
+        </span>
       </label>
 
       <span 
@@ -142,6 +148,11 @@ export default Vue.extend({
       default:null,
       required:false,
       description:"Textarea type input max-height",
+    },
+    required:{
+      type:Boolean,
+      default:false,
+      required:false
     },
     resize:{
       type:Boolean,
@@ -374,6 +385,10 @@ export default Vue.extend({
     color: $color-black;
 
     @include font-base-md();
+  }
+
+  .inputTextLabelRequired {
+    color: $color-error;
   }
 
   .inputTextLabelWrapper {


### PR DESCRIPTION
To indicate a form input is required, the UX team has been putting
a red asterisk as part of the label.  This will allow when the
developer uses the required attribute to ensure the label visually
reflects this.